### PR TITLE
Add bash script for setting up Ansible control node

### DIFF
--- a/setup-ansible-node/README.md
+++ b/setup-ansible-node/README.md
@@ -1,0 +1,58 @@
+This directory containes a bunch of bash scripts to prepare node for setting up ansible control and target node.
+
+Three main files are as follows:
+1 - setup-target-node.sh
+2 - setup-control-node.sh
+3 - vars.txt
+
+vars.txt contains the variables, their description is as follows:
+	- cnode_username: username of the control node that will be used as ansible_user (default: ansible)
+	- cnode_password: password of the ansible_user on control node (default: ansible)
+	- tnode_username: username of the target node ansible_user (default: ansible)
+	- tnode_password: password of the ansible_user on target node (default: ansible)
+	- tnode_hostname: hostname or ip of the target node to copy ssh key to (default: ansible) 
+
+setup-target-node.sh reads variables from vars.txt and prepares the node for being managed by ansible it involves the following steps:
+
+	- Create user (username: tnode_username, password: tnode_password).
+	- Adds the user in wheel group.
+	- Gives the user passwordless sudo access.
+	- Install dependencies (Python3).
+	- Creates an alias of /usr/bin/python3 as python.
+
+setup-control-node.sh reads variables from vars.txt and prepares the node for managing ansible target nodes. It does the following steps:
+
+	- Create user (username: cnode_username, password: cnode_password).
+	- Adds the user in wheel group.
+	- Gives the user passwordless sudo access.
+	- Generate ssh keys (as user cnode_username).
+	- Copy ssh public key to the target node <tnode_username>@<tnode_hostname>
+	- Install Packages (Python3, Ansible).
+
+
+For creating a single node (control + target), vars.txt needs to be populated with the proper values. An example is given below:
+
+vars.txt
+```
+cnode_username=ansible
+cnode_password=password
+tnode_username=ansible
+tnode_password=password
+tnode_hostname=localhost
+```
+now run following command to setup the node.
+```
+setup-control-node.sh
+```
+To confirm proper setup:
+	- switch to <cnode_username> 'su - ansible'
+	- run ansible ad-hoc command 'ansible localhost -m ping -u ansible'
+
+Response should be as follows.
+
+```
+localhost | SUCCESS => {
+    "changed": false,
+    "ping": "pong"
+}
+```

--- a/setup-ansible-node/scripts/copy-ssh-id.sh
+++ b/setup-ansible-node/scripts/copy-ssh-id.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+
+set username [lindex $argv 0];
+set password [lindex $argv 1];
+set hostnode [lindex $argv 2];
+
+if {$username eq ""} {set user ansible}
+if {$password eq ""} {set pass ansible}
+if {$hostnode eq ""} {set host localhost}
+
+spawn ssh-copy-id -f "$username@$hostnode"
+expect {
+    "fingerprint" {send "yes\n"}
+    "password:" {send "$password\n"}
+    eof
+}
+expect {
+    "password:" {send "$password\n"}
+    eof
+}
+expect eof

--- a/setup-ansible-node/scripts/create-pwless-sudoer-user.sh
+++ b/setup-ansible-node/scripts/create-pwless-sudoer-user.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+user=${1:-ansible}
+passwd=${2:-ansible}
+
+adduser $user
+echo $passwd | passwd $user --stdin
+usermod -a -G wheel $user
+echo $user 'ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible
+grep -qxF '#includedir /etc/sudoers.d' /etc/sudoers || echo '#includedir /etc/sudoers.d' >> /etc/sudoers
+

--- a/setup-ansible-node/scripts/gen-ssh-key.sh
+++ b/setup-ansible-node/scripts/gen-ssh-key.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+username=${1:-$USER}
+
+sudo su - $username -c 'FILE=$HOME/.ssh/id_rsa.pub; if [ ! -f "$FILE" ]; then ssh-keygen -b 2048 -t rsa -f $HOME/.ssh/id_rsa -q -N ""; fi'
+

--- a/setup-ansible-node/scripts/install-ansible.sh
+++ b/setup-ansible-node/scripts/install-ansible.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sudo yum install ansible -y

--- a/setup-ansible-node/scripts/install-dependencies.sh
+++ b/setup-ansible-node/scripts/install-dependencies.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sudo yum install expect -y
+sudo yum install epel-release -y

--- a/setup-ansible-node/scripts/install-python.sh
+++ b/setup-ansible-node/scripts/install-python.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sudo yum install python3 -y
+sudo alternatives --set python /usr/bin/python3

--- a/setup-ansible-node/setup-control-node.sh
+++ b/setup-ansible-node/setup-control-node.sh
@@ -16,3 +16,7 @@ cp ./scripts/copy-ssh-id.sh /home/${cnode_username}/
 sudo su - $cnode_username -c "~/copy-ssh-id.sh ${tnode_username} ${tnode_password} ${tnode_hostname}"
 source ./scripts/install-python.sh
 source ./scripts/install-ansible.sh
+
+echo "You can run the following command to verify the setup."
+echo "ansible ${tnode_hostname} -m ping -u ${tnode_username}"
+echo""

--- a/setup-ansible-node/setup-control-node.sh
+++ b/setup-ansible-node/setup-control-node.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+source vars.txt
+
+cnode_username=${cnode_username:-"ansible"}
+cnode_password=${cnode_password:-"ansible"}
+tnode_username=${tnode_username:-"ansible"}
+tnode_password=${tnode_password:-"ansible"}
+tnode_hostname=${tnode_hostname:-"localhost"}
+
+
+./scripts/create-pwless-sudoer-user.sh $cnode_username $cnode_password
+./scripts/gen-ssh-key.sh $cnode_username
+cp ./scripts/copy-ssh-id.sh /home/${cnode_username}/
+
+sudo su - $cnode_username -c "~/copy-ssh-id.sh ${tnode_username} ${tnode_password} ${tnode_hostname}"
+./scripts/install-python.sh
+./scripts/install-ansible.sh

--- a/setup-ansible-node/setup-control-node.sh
+++ b/setup-ansible-node/setup-control-node.sh
@@ -8,11 +8,11 @@ tnode_username=${tnode_username:-"ansible"}
 tnode_password=${tnode_password:-"ansible"}
 tnode_hostname=${tnode_hostname:-"localhost"}
 
-
-./scripts/create-pwless-sudoer-user.sh $cnode_username $cnode_password
-./scripts/gen-ssh-key.sh $cnode_username
+source ./scripts/install-packages.sh
+source ./scripts/create-pwless-sudoer-user.sh $cnode_username $cnode_password
+source ./scripts/gen-ssh-key.sh $cnode_username
 cp ./scripts/copy-ssh-id.sh /home/${cnode_username}/
 
 sudo su - $cnode_username -c "~/copy-ssh-id.sh ${tnode_username} ${tnode_password} ${tnode_hostname}"
-./scripts/install-python.sh
-./scripts/install-ansible.sh
+source ./scripts/install-python.sh
+source ./scripts/install-ansible.sh

--- a/setup-ansible-node/setup-control-node.sh
+++ b/setup-ansible-node/setup-control-node.sh
@@ -8,7 +8,7 @@ tnode_username=${tnode_username:-"ansible"}
 tnode_password=${tnode_password:-"ansible"}
 tnode_hostname=${tnode_hostname:-"localhost"}
 
-source ./scripts/install-packages.sh
+source ./scripts/install-dependencies.sh
 source ./scripts/create-pwless-sudoer-user.sh $cnode_username $cnode_password
 source ./scripts/gen-ssh-key.sh $cnode_username
 cp ./scripts/copy-ssh-id.sh /home/${cnode_username}/

--- a/setup-ansible-node/setup-target-node.sh
+++ b/setup-ansible-node/setup-target-node.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source vars.txt
+
+username=${tnode_username:-"ansible"}
+password=${tnode_password:-"ansible"}
+
+source ./scripts/create-pwless-sudoer-user.sh $username $password
+source ./scripts/install-python.sh

--- a/setup-ansible-node/vars.txt
+++ b/setup-ansible-node/vars.txt
@@ -1,0 +1,5 @@
+cnode_username=ansible
+cnode_password=ansible
+tnode_username=ansible
+tnode_password=ansible
+tnode_hostname=localhost


### PR DESCRIPTION
Code for setting up ansible target and control nodes. It automates the process of user creation, key sharing and packages installation.